### PR TITLE
Add support for Comments plugin

### DIFF
--- a/SpamGuardPlugin.php
+++ b/SpamGuardPlugin.php
@@ -68,6 +68,21 @@ class SpamGuardPlugin extends BasePlugin
 				}
 			});
 		}
+
+		#
+		# Support for Comments
+		if ($this->getSettings()->getAttribute('enableCommentsSupport'))
+		{
+			craft()->on('comments.onBeforeSaveComment', function(Event $event)
+			{
+				$spam = spamGuard()->detectCommentsSpam($event->params['comment']);
+
+				if ($spam)
+				{
+					$event->performAction = false;
+				}
+			});
+		}
 	}
 
 	/**
@@ -137,6 +152,7 @@ class SpamGuardPlugin extends BasePlugin
 			'enableContactFormSupport'	=> array(AttributeType::Bool,	'default'	=> true),
 			'enableGuestEntriesSupport'	=> array(AttributeType::Bool,	'default'	=> true),
 			'enableSproutFormsSupport'	=> array(AttributeType::Bool,	'default'	=> true),
+			'enableCommentsSupport'		=> array(AttributeType::Bool,	'default'	=> true),
 			'logSubmissions'			=> array(AttributeType::Bool,	'default'	=> false),
 			'enableCpTab'				=> array(AttributeType::Bool,	'default'	=> true),
 			'pluginAlias'				=> AttributeType::String,

--- a/services/SpamGuardService.php
+++ b/services/SpamGuardService.php
@@ -316,6 +316,26 @@ class SpamGuardService extends BaseApplicationComponent
 	}
 
 	/**
+	 * Comments onBeforeSaveComment()
+	 *
+	 * Allows you to use spamguard alongside the Comments plugin
+	 *
+	 * @since	0.6.0
+	 * @param	array $form
+	 * @return	boolean
+	 */
+	public function detectCommentsSpam(BaseModel $comment)
+	{
+		$data = array(
+			'content'	=> $comment->comment,
+			'author'	=> $comment->author->fullName,
+			'email'		=> $comment->author->email,
+		);
+
+		return $this->isSpam($data);
+	}
+
+	/**
 	 * Deletes a log by id
 	 *
 	 * @param $id

--- a/templates/_settings.html
+++ b/templates/_settings.html
@@ -79,6 +79,16 @@
 					errors:			""
 				})
 			}}
+			{{
+				forms.checkboxField({
+					id:				"enableCommentsSupport",
+					name:			"enableCommentsSupport",
+					label:			"Enable Comments Support?"|t,
+					checked:		settings.enableCommentsSupport,
+					instructions:	"This features requires [Comments 0.4.0](https://github.com/engram-design/Comments) or above"|t,
+					errors:			""
+				})
+			}}
 		</div>
 
 		<div class="spamguardSection">


### PR DESCRIPTION
Not sure if you're still maintaining this plugin, but it'd be great to add support for the [Comments](https://github.com/engram-design/Comments) plugin. If there is a way to do this through the Comments plugin itself, that might be a better option - I just couldn't find any resources on that.

Let me know if you need a hand with anything or have any questions.
